### PR TITLE
[FE] ProductItem 컴포넌트 css 수정

### DIFF
--- a/client/src/components/ProductItem.jsx
+++ b/client/src/components/ProductItem.jsx
@@ -1,30 +1,36 @@
 import styled from "styled-components";
 
 const Item = styled.div`
-  width: 150px;
   margin: 0 auto;
   padding: 10px;
   font-size: 14px;
-  font-weight: 400;
+
+  .image_wrapper {
+    overflow: hidden;
+    margin-bottom: 6px;
+  }
 
   .name {
+    margin-bottom: 5px;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
-    height: 40px;
     line-height: 20px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .name,
+
   .price {
     margin-bottom: 5px;
   }
 
   img {
     width: 100%;
-    height: 150px;
-    margin-bottom: 6px;
+    transition: 1s;
+
+    &:hover {
+      transform: scale(1.05);
+    }
   }
 `;
 
@@ -32,9 +38,13 @@ function ProductItem({ element }) {
   return (
     <Item>
       <a>
-        <img src={element.image}></img>
+        <div className="image_wrapper">
+          <img src={element.image}></img>
+        </div>
+
         <div>
           <h3 className="name">{element.name}</h3>
+
           <div className="price">{element.price.toLocaleString()}원</div>
         </div>
       </a>

--- a/client/src/components/ProductItem.jsx
+++ b/client/src/components/ProductItem.jsx
@@ -1,10 +1,21 @@
 import styled from "styled-components";
 
 const Item = styled.div`
+  width: 150px;
+  margin: 0 auto;
+  padding: 10px;
   font-size: 14px;
   font-weight: 400;
-  padding: 10px;
 
+  .name {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    height: 40px;
+    line-height: 20px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   .name,
   .price {
     margin-bottom: 5px;
@@ -12,6 +23,7 @@ const Item = styled.div`
 
   img {
     width: 100%;
+    height: 150px;
     margin-bottom: 6px;
   }
 `;


### PR DESCRIPTION
## 무슨 이유로 코드를 변경했는지
ProductItem 컴포넌트 css 수정

## 새로 사용한 기술 링크
없음

## 관련 이슈
#42 - ProductItem 컴포넌트 css 수정

## 완료 사항
1. ProductItem 컴포넌트 css 수정

1-1. 이미지 호버 시 이미지 확대효과
![Jan-11-2023 21-21-46](https://user-images.githubusercontent.com/57666791/211807011-b1a60315-63ff-4c92-b347-debae66da095.gif)

1-2. 상품명 2줄 넘어갈 시 ...으로 오버플로우 처리
<img width="224" alt="image" src="https://user-images.githubusercontent.com/57666791/211807199-34d3c9a3-65e5-49e2-a149-bf55051e5d89.png">
