### PR TITLE
[BE] 주문, 결제 FE와 API 요구사항 조정

### DIFF
--- a/server/culinari/src/main/java/com/codestates/culinari/order/constant/StatusType.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/constant/StatusType.java
@@ -3,8 +3,10 @@ package com.codestates.culinari.order.constant;
 import lombok.Getter;
 
 public enum StatusType {
-    STAND_BY("대기 중"),
-    SHIPPING("배송 중"),
+    ORDER_RECEIVED("주문 접수"),
+    PREPARING_SHIPPING("배송 준비중"),
+    START_SHIPPING("배송 출발"),
+    ON_SHIPPING("배송중"),
     COMPLETE("배송 완료");
 
     @Getter

--- a/server/culinari/src/main/java/com/codestates/culinari/order/controller/CartController.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/controller/CartController.java
@@ -1,6 +1,7 @@
 package com.codestates.culinari.order.controller;
 
 import com.codestates.culinari.config.security.dto.CustomPrincipal;
+import com.codestates.culinari.order.dto.request.CartDelete;
 import com.codestates.culinari.order.dto.request.CartPatch;
 import com.codestates.culinari.order.dto.request.CartPost;
 import com.codestates.culinari.order.dto.response.CartResponse;
@@ -71,12 +72,12 @@ public class CartController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @DeleteMapping("/{cart-id}")
+    @DeleteMapping
     public ResponseEntity deleteCart(
-            @PathVariable("cart-id") @Positive Long cartId,
+            @Valid @RequestBody CartDelete delete,
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
-        cartService.deleteCart(cartId, principal);
+        cartService.deleteCarts(delete, principal);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/controller/OrdersController.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/controller/OrdersController.java
@@ -1,6 +1,7 @@
 package com.codestates.culinari.order.controller;
 
 import com.codestates.culinari.config.security.dto.CustomPrincipal;
+import com.codestates.culinari.order.dto.response.OrderDetailResponse;
 import com.codestates.culinari.order.dto.response.OrderResponse;
 import com.codestates.culinari.order.service.OrdersService;
 import com.codestates.culinari.pagination.PageResponseDto;
@@ -47,6 +48,25 @@ public class OrdersController {
 
         return new ResponseEntity<>(
                 new PageResponseDto<>(orders, pageOrders, barNumber),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/details")
+    public ResponseEntity getOrderDetails(
+            @Min(0) @RequestParam(defaultValue = "0", required = false) int page,
+            @Positive @RequestParam(defaultValue = "10", required = false) int size,
+            @Positive @RequestParam(defaultValue = "3") Integer searchMonths,
+            @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
+
+        Page<OrderDetailResponse> pageOrderDetails = ordersService.readOrderDetails(searchMonths, pageable, principal);
+        List<OrderDetailResponse> orderDetails = pageOrderDetails.getContent();
+        List<Integer> barNumber = paginationService.getPaginationBarNumbers(page, pageOrderDetails.getTotalPages());
+
+        return new ResponseEntity<>(
+                new PageResponseDto<>(orderDetails, pageOrderDetails, barNumber),
                 HttpStatus.OK
         );
     }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/dto/OrderDetailDto.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/dto/OrderDetailDto.java
@@ -11,7 +11,7 @@ public record OrderDetailDto(
 ) {
 
     public static OrderDetailDto of(Integer quantity) {
-        return new OrderDetailDto(quantity, StatusType.STAND_BY);
+        return new OrderDetailDto(quantity, StatusType.ORDER_RECEIVED);
     }
 
     public OrderDetail toEntity(Orders orders, Product product) {

--- a/server/culinari/src/main/java/com/codestates/culinari/order/dto/request/CartDelete.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/dto/request/CartDelete.java
@@ -1,0 +1,18 @@
+package com.codestates.culinari.order.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CartDelete(
+        @NotNull(message = "해당 값은 필수입니다.")
+        @Size(min = 1, message = "최소 1개 이상의 상품을 주문해야합니다.")
+        List<@Positive(message = "해당 값은 1이상이어야 합니다.") Long> cartIds
+) {
+
+    public static CartDelete of(List<Long> cartIds) {
+        return new CartDelete(cartIds);
+    }
+}

--- a/server/culinari/src/main/java/com/codestates/culinari/order/dto/request/CartPost.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/dto/request/CartPost.java
@@ -1,25 +1,31 @@
 package com.codestates.culinari.order.dto.request;
 
 import com.codestates.culinari.order.dto.CartDto;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
 
 public record CartPost(
         @NotNull(message = "해당 값은 필수입니다.")
-        @Positive(message = "해당 값은 1이상이어야 합니다.")
-        Long productId,
-        @NotNull
-        @Positive(message = "장바구니 수량은 1 이상 입니다.")
-        Integer quantity
+        @Size(min = 1, message = "최소 1개 이상의 상품을 주문해야합니다.")
+        List<@Valid CartInfo> cartItems
 ) {
 
-    public static CartPost of(Long productId, Integer quantity) {
-        return new CartPost(productId, quantity);
-    }
-
-    public CartDto toDto() {
-        return CartDto.of(
-                quantity
-        );
+    public record CartInfo(
+            @NotNull(message = "해당 값은 필수입니다.")
+            @Positive(message = "해당 값은 1이상이어야 합니다.")
+            Long productId,
+            @NotNull(message = "해당 값은 필수입니다.")
+            @Positive(message = "장바구니 수량은 1 이상 입니다.")
+            Integer quantity
+    ) {
+        public CartDto toDto() {
+            return CartDto.of(
+                    quantity
+            );
+        }
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/dto/response/CartResponse.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/dto/response/CartResponse.java
@@ -18,8 +18,7 @@ public record CartResponse(
         return CartResponse.of(
                 entity.getId(),
                 entity.getQuantity(),
-                // TODO: 이후 ProductResponseToPage.from(entity.getProduct())
-                ProductResponseToPage.from(ProductDto.from(entity.getProduct()))
+                ProductResponseToPage.from(entity.getProduct())
         );
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/dto/response/OrderDetailResponse.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/dto/response/OrderDetailResponse.java
@@ -21,8 +21,7 @@ public record OrderDetailResponse(
                 entity.getId(),
                 entity.getQuantity(),
                 entity.getStatusType(),
-                // TODO: 이후 ProductResponseToPage.from(entity.getProduct())
-                ProductResponseToPage.from(ProductDto.from(entity.getProduct()))
+                ProductResponseToPage.from(entity.getProduct())
         );
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/CartRepository.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/CartRepository.java
@@ -1,13 +1,14 @@
 package com.codestates.culinari.order.repository;
 
 import com.codestates.culinari.order.entitiy.Cart;
+import com.codestates.culinari.order.repository.querydsl.CartRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface CartRepository extends JpaRepository<Cart, Long> {
+public interface CartRepository extends JpaRepository<Cart, Long>, CartRepositoryCustom {
 
     Page<Cart> findAllByProfile_Id(Pageable pageable, Long profileId);
 

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/OrderDetailRepository.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/OrderDetailRepository.java
@@ -1,13 +1,14 @@
 package com.codestates.culinari.order.repository;
 
 import com.codestates.culinari.order.entitiy.OrderDetail;
+import com.codestates.culinari.order.repository.querydsl.OrderDetailRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> {
+public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long>, OrderDetailRepositoryCustom {
 
     Optional<OrderDetail> findByIdAndOrders_Profile_Id(Long orderDetailId, Long profileId);
 

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/CartRepositoryCustom.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/CartRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.codestates.culinari.order.repository.querydsl;
+
+import java.util.List;
+
+public interface CartRepositoryCustom {
+    void deleteAllByIdsAndProfile_Id(List<Long> cartIds, Long profileId);
+    void deleteAllByOrderId(Long orderId);
+}

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/CartRepositoryCustomImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/CartRepositoryCustomImpl.java
@@ -1,0 +1,55 @@
+package com.codestates.culinari.order.repository.querydsl;
+
+import com.codestates.culinari.global.exception.BusinessLogicException;
+import com.codestates.culinari.global.exception.ExceptionCode;
+import com.codestates.culinari.order.entitiy.Cart;
+import com.codestates.culinari.order.entitiy.QCart;
+import com.codestates.culinari.order.entitiy.QOrderDetail;
+import com.codestates.culinari.order.entitiy.QOrders;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class CartRepositoryCustomImpl extends QuerydslRepositorySupport implements CartRepositoryCustom {
+    public CartRepositoryCustomImpl() { super(Cart.class); }
+
+    @Override
+    public void deleteAllByIdsAndProfile_Id(List<Long> cartIds, Long profileId) {
+        QCart cart = QCart.cart;
+
+        BooleanExpression condition = cart.id.in(cartIds)
+                .and(cart.profile.id.eq(profileId));
+        JPQLQuery<Cart> count = from(cart).where(condition);
+
+        if (count.fetchCount() != cartIds.size()) {
+            throw new BusinessLogicException(ExceptionCode.CART_NOT_FOUND);
+        }
+
+        delete(cart)
+                .where(condition)
+                .execute();
+    }
+
+    @Override
+    public void deleteAllByOrderId(Long orderId) {
+        QCart cart = QCart.cart;
+        QCart cartSub = new QCart("cartSub");
+        QOrders order = QOrders.orders;
+        QOrderDetail orderDetail = QOrderDetail.orderDetail;
+
+        delete(cart)
+                .where(cart.id.in(
+                        JPAExpressions
+                                .select(cartSub.id)
+                                .from(cartSub)
+                                .where(
+                                        cart.profile.id.eq(JPAExpressions.select(order.profile.id).from(order).where(order.id.eq(orderId)))
+                                                .and(cart.product.id.in(JPAExpressions.select(orderDetail.product.id).from(orderDetail).where(orderDetail.orders.id.eq(orderId))))
+                                )
+                ))
+                .execute();
+    }
+}

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustom.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.codestates.culinari.order.repository.querydsl;
+
+import com.codestates.culinari.order.entitiy.OrderDetail;
+import com.codestates.culinari.order.entitiy.Orders;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OrderDetailRepositoryCustom {
+    List<OrderDetail> findAllPaidByIdAndPaymentKeyAndProfileId(List<Long> orderDetailIds, String paymentKey, Long profileId);
+
+    Page<OrderDetail> findAllCreatedAfterAndProfile_Id(LocalDateTime createdAfterDateTime, Long profileId, Pageable pageable);
+}

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustomImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustomImpl.java
@@ -1,0 +1,68 @@
+package com.codestates.culinari.order.repository.querydsl;
+
+import com.codestates.culinari.global.exception.BusinessLogicException;
+import com.codestates.culinari.global.exception.ExceptionCode;
+import com.codestates.culinari.order.entitiy.OrderDetail;
+import com.codestates.culinari.order.entitiy.Orders;
+import com.codestates.culinari.order.entitiy.QOrderDetail;
+import com.codestates.culinari.order.entitiy.QOrders;
+import com.codestates.culinari.payment.entity.QPayment;
+import com.codestates.culinari.payment.entity.QRefund;
+import com.codestates.culinari.user.entitiy.QProfile;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class OrderDetailRepositoryCustomImpl extends QuerydslRepositorySupport implements OrderDetailRepositoryCustom {
+    public OrderDetailRepositoryCustomImpl() {
+        super(OrderDetail.class);
+    }
+
+    @Override
+    public List<OrderDetail> findAllPaidByIdAndPaymentKeyAndProfileId(List<Long> orderDetailIds, String paymentKey, Long profileId) {
+        QOrderDetail orderDetail = QOrderDetail.orderDetail;
+        QPayment payment = QPayment.payment;
+        QRefund refund = QRefund.refund;
+
+        List<OrderDetail> orderDetails =
+                from(orderDetail)
+                        .where(orderDetail.orders.id.eq(
+                                JPAExpressions.select(payment.id).from(payment)
+                                        .where(
+                                                payment.paySuccessTf.eq(true)
+                                                .and(payment.paymentKey.eq(paymentKey))
+                                                .and(payment.profile.id.eq(profileId))
+                                        ))
+                                .and(orderDetail.id.in(orderDetailIds))
+                                .and(orderDetail.id.notIn(JPAExpressions.select(refund.orderDetail.id).from(refund)))
+                        )
+                        .fetch();
+
+        if (orderDetails.size() != orderDetailIds.size()) throw new BusinessLogicException(ExceptionCode.ORDER_DETAIL_NOT_FOUND);
+
+        return orderDetails;
+    }
+
+    @Override
+    public Page<OrderDetail> findAllCreatedAfterAndProfile_Id(LocalDateTime createdAfterDateTime, Long profileId, Pageable pageable) {
+        QOrderDetail orderDetail = QOrderDetail.orderDetail;
+        QPayment payment = QPayment.payment;
+        QProfile profile = QProfile.profile;
+
+        JPQLQuery<OrderDetail> query =
+                from(orderDetail)
+                        .innerJoin(orderDetail.orders.profile, profile).fetchJoin()
+                        .where(orderDetail.createdAt.gt(createdAfterDateTime)
+                                .and(profile.id.eq(profileId))
+                                .and(orderDetail.orders.id.in(JPAExpressions.select(payment.order.id).from(payment).where(payment.paySuccessTf.eq(true)))));
+        List<OrderDetail> orderDetails = getQuerydsl().applyPagination(pageable, query).fetch();
+
+        return new PageImpl<>(orderDetails, pageable, query.fetchCount());
+    }
+}

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrdersRepositoryCustomImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrdersRepositoryCustomImpl.java
@@ -2,7 +2,9 @@ package com.codestates.culinari.order.repository.querydsl;
 
 import com.codestates.culinari.order.entitiy.Orders;
 import com.codestates.culinari.order.entitiy.QOrders;
+import com.codestates.culinari.payment.entity.QPayment;
 import com.codestates.culinari.user.entitiy.QProfile;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -21,14 +23,15 @@ public class OrdersRepositoryCustomImpl extends QuerydslRepositorySupport implem
     @Override
     public Page<Orders> findAllCreatedAfterAndProfile_Id(LocalDateTime createdAfterDateTime, Long profileId, Pageable pageable) {
         QOrders order = QOrders.orders;
+        QPayment payment = QPayment.payment;
         QProfile profile = QProfile.profile;
 
         JPQLQuery<Orders> query =
                 from(order)
                         .innerJoin(order.profile, profile).fetchJoin()
                         .where(order.createdAt.gt(createdAfterDateTime)
-                                .and(profile.id.eq(profileId)))
-                        .orderBy(order.createdAt.desc());
+                                .and(profile.id.eq(profileId))
+                                .and(order.id.in(JPAExpressions.select(payment.order.id).from(payment).where(payment.paySuccessTf.eq(true)))));
         List<Orders> orders = getQuerydsl().applyPagination(pageable, query).fetch();
 
         return new PageImpl<>(orders, pageable, query.fetchCount());

--- a/server/culinari/src/main/java/com/codestates/culinari/order/service/CartService.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/service/CartService.java
@@ -1,11 +1,14 @@
 package com.codestates.culinari.order.service;
 
 import com.codestates.culinari.config.security.dto.CustomPrincipal;
+import com.codestates.culinari.order.dto.request.CartDelete;
 import com.codestates.culinari.order.dto.request.CartPatch;
 import com.codestates.culinari.order.dto.request.CartPost;
 import com.codestates.culinari.order.dto.response.CartResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface CartService {
 
@@ -15,5 +18,5 @@ public interface CartService {
 
     void updateCart(CartPatch patch, Long cartId, CustomPrincipal principal);
 
-    void deleteCart(Long cartId, CustomPrincipal principal);
+    void deleteCarts(CartDelete delete, CustomPrincipal principal);
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/service/OrdersService.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/service/OrdersService.java
@@ -1,6 +1,7 @@
 package com.codestates.culinari.order.service;
 
 import com.codestates.culinari.config.security.dto.CustomPrincipal;
+import com.codestates.culinari.order.dto.response.OrderDetailResponse;
 import com.codestates.culinari.order.dto.response.OrderResponse;
 import com.codestates.culinari.user.dto.response.ProfileMyPageReviewEnableResponse;
 import org.springframework.data.domain.Page;
@@ -11,4 +12,6 @@ public interface OrdersService {
     Page<ProfileMyPageReviewEnableResponse> readEnableReviewOrder(CustomPrincipal principal, Pageable pageable);
 
     Page<OrderResponse> readOrders(Integer searchMonths, Pageable pageable, CustomPrincipal principal);
+
+    Page<OrderDetailResponse> readOrderDetails(Integer searchMonths, Pageable pageable, CustomPrincipal principal);
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/CartServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/CartServiceImpl.java
@@ -69,13 +69,15 @@ public class CartServiceImpl implements CartService {
     }
 
     @Override
-    public void deleteCart(Long cartId, CustomPrincipal principal) {
+    public void deleteCarts(CartDelete delete, CustomPrincipal principal) {
         verifyPrincipal(principal);
 
-        if(cartRepository.existsByIdAndProfile_Id(cartId, principal.profileId()))
-            cartRepository.deleteById(cartId);
-        else
+        try {
+            cartRepository.deleteAllByIdsAndProfile_Id(delete.cartIds(), principal.profileId());
+        } catch (Exception e) {
             throw new BusinessLogicException(ExceptionCode.CART_NOT_FOUND);
+
+        }
     }
 
     public void verifyPrincipal(CustomPrincipal principal) {

--- a/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/CartServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/CartServiceImpl.java
@@ -4,6 +4,7 @@ import com.codestates.culinari.config.security.dto.CustomPrincipal;
 import com.codestates.culinari.global.exception.BusinessLogicException;
 import com.codestates.culinari.global.exception.ExceptionCode;
 import com.codestates.culinari.order.dto.CartDto;
+import com.codestates.culinari.order.dto.request.CartDelete;
 import com.codestates.culinari.order.dto.request.CartPatch;
 import com.codestates.culinari.order.dto.request.CartPost;
 import com.codestates.culinari.order.dto.response.CartResponse;
@@ -20,6 +21,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -33,20 +36,22 @@ public class CartServiceImpl implements CartService {
     public void createCart(CartPost post, CustomPrincipal principal) {
         verifyPrincipal(principal);
 
-        Product product = productRepository.findById(post.productId())
-                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PRODUCT_NOT_FOUND));
-        Profile profile = profileRepository.getReferenceById(principal.profileId());
-        CartDto dto = post.toDto();
+        post.cartItems().forEach(cartInfo -> {
+                    Product product = productRepository.findById(cartInfo.productId())
+                            .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PRODUCT_NOT_FOUND));
+                    Profile profile = profileRepository.getReferenceById(principal.profileId());
+                    CartDto dto = cartInfo.toDto();
 
-        cartRepository.findByProfile_IdAndProduct_Id(profile.getId(), product.getId())
-                .ifPresentOrElse(
-                        cart -> {
-                            cart.updateQuantity(cart.getQuantity() + dto.quantity());
-                            cartRepository.save(cart);
-                        }, () -> {
-                            cartRepository.save(dto.toEntity(profile, product));
-                        }
-                );
+                    cartRepository.findByProfile_IdAndProduct_Id(profile.getId(), product.getId())
+                            .ifPresentOrElse(
+                                    cart -> {
+                                        cart.updateQuantity(cart.getQuantity() + dto.quantity());
+                                        cartRepository.save(cart);
+                                    }, () -> {
+                                        cartRepository.save(dto.toEntity(profile, product));
+                                    }
+                            );
+                });
     }
 
     @Transactional(readOnly = true)

--- a/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/OrdersServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/OrdersServiceImpl.java
@@ -3,6 +3,7 @@ package com.codestates.culinari.order.service.impl;
 import com.codestates.culinari.config.security.dto.CustomPrincipal;
 import com.codestates.culinari.global.exception.BusinessLogicException;
 import com.codestates.culinari.global.exception.ExceptionCode;
+import com.codestates.culinari.order.dto.response.OrderDetailResponse;
 import com.codestates.culinari.order.dto.response.OrderResponse;
 import com.codestates.culinari.order.repository.OrderDetailRepository;
 import com.codestates.culinari.order.repository.OrdersRepository;
@@ -39,6 +40,14 @@ public class OrdersServiceImpl implements OrdersService {
 
         return ordersRepository.findAllCreatedAfterAndProfile_Id(LocalDateTime.now().minusMonths(searchMonths), principal.profileId(), pageable)
                 .map(OrderResponse::from);
+    }
+
+    @Override
+    public Page<OrderDetailResponse> readOrderDetails(Integer searchMonths, Pageable pageable, CustomPrincipal principal) {
+        verifyPrincipal(principal);
+
+        return orderDetailRepository.findAllCreatedAfterAndProfile_Id(LocalDateTime.now().minusMonths(searchMonths), principal.profileId(), pageable)
+                .map(OrderDetailResponse::from);
     }
 
     public void verifyPrincipal(CustomPrincipal principal) {

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/controller/PaymentController.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/controller/PaymentController.java
@@ -103,7 +103,7 @@ public class PaymentController {
 
     @PostMapping("/cancel")
     public ResponseEntity requestPaymentCancel(
-            @RequestBody RefundRequest request,
+            @Valid @RequestBody RefundRequest request,
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
             //PaymentTossDto response =

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/controller/PaymentController.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/controller/PaymentController.java
@@ -78,16 +78,13 @@ public class PaymentController {
             @RequestParam BigDecimal amount
     ) {
         paymentService.verifyRequest(paymentKey, orderId, amount);
-        try {
-            PaymentTossDto response = paymentService.requestApprovalPayment(paymentKey, orderId, amount);
+        //PaymentTossDto response =
+        paymentService.requestApprovalPayment(paymentKey, orderId, amount);
 
-            return new ResponseEntity<>(
-                    new SingleResponseDto<>(response),
-                    HttpStatus.OK
-            );
-        } catch (Exception e) {
-            throw new BusinessLogicException(ExceptionCode.TOSS_REQUEST_FAIL);
-        }
+        return new ResponseEntity<>(
+                //new SingleResponseDto<>(response),
+                HttpStatus.OK
+        );
     }
 
     @GetMapping("/fail")
@@ -109,15 +106,13 @@ public class PaymentController {
             @RequestBody RefundRequest request,
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
-        try {
-            PaymentTossDto response = paymentService.requestPaymentCancel(request, principal);
+            //PaymentTossDto response =
+            paymentService.requestPaymentCancel(request, principal);
 
             return new ResponseEntity<>(
-                    new SingleResponseDto<>(response),
+                    //new SingleResponseDto<>(response),
                     HttpStatus.OK
             );
-        } catch (Exception e) {
-            throw new BusinessLogicException(ExceptionCode.TOSS_REQUEST_FAIL);
-        }
+
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/dto/RefundDto.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/dto/RefundDto.java
@@ -4,13 +4,12 @@ import com.codestates.culinari.order.entitiy.OrderDetail;
 import com.codestates.culinari.payment.entity.Refund;
 
 public record RefundDto(
-        Long orderDetailId,
         String paymentKey,
         String cancelReason
 ) {
 
-    public static RefundDto of(Long orderDetailId, String paymentKey, String cancelReason) {
-        return new RefundDto(orderDetailId, paymentKey, cancelReason);
+    public static RefundDto of(String paymentKey, String cancelReason) {
+        return new RefundDto(paymentKey, cancelReason);
     }
 
     public Refund toEntity(OrderDetail orderDetail) {

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/dto/request/PaymentRequest.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/dto/request/PaymentRequest.java
@@ -8,8 +8,9 @@ import java.util.List;
 public record PaymentRequest(
         @NotNull(message = "결제 수단은 필수입니다.")
         PayType payType,
+        @NotNull(message = "해당 값은 필수입니다.")
         @Size(min = 1, message = "최소 1개 이상의 상품을 주문해야합니다.")
-        List<@Positive Long> productIds,
+        List<@Positive(message = "해당 값은 1이상이어야 합니다.") Long> productIds,
         @NotBlank(message = "주소 입력은 필수입니다.")
         String address,
         @NotBlank(message = "수령자 입력은 필수입니다.")

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/dto/request/RefundRequest.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/dto/request/RefundRequest.java
@@ -4,12 +4,15 @@ import com.codestates.culinari.payment.dto.RefundDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
 
 public record RefundRequest (
         @NotNull(message = "해당 값은 필수입니다.")
-        @Positive(message = "해당 값은 1이상이어야 합니다.")
-        Long orderDetailId,
+        @Size(min = 1, message = "최소 1개 이상의 상품을 주문해야합니다.")
+        List<@Positive(message = "해당 값은 1이상이어야 합니다.") Long> orderDetailIds,
         @NotBlank(message = "결제 키는 빈칸일 수 없습니다.")
         @Length(max = 200, message = "결재 키는 200자 이하입니다.")
         String paymentKey,
@@ -17,15 +20,11 @@ public record RefundRequest (
         String cancelReason
 ) {
 
-    public static RefundRequest of(Long orderDetailId, String paymentKey, String cancelReason) {
-        return new RefundRequest(orderDetailId, paymentKey, cancelReason);
+    public static RefundRequest of(List<Long> orderDetailIds, String paymentKey, String cancelReason) {
+        return new RefundRequest(orderDetailIds, paymentKey, cancelReason);
     }
 
     public RefundDto toDto() {
-        return RefundDto.of(
-                orderDetailId,
-                paymentKey,
-                cancelReason
-        );
+        return RefundDto.of(paymentKey, cancelReason);
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/dto/response/PaymentInfoResponse.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/dto/response/PaymentInfoResponse.java
@@ -9,19 +9,23 @@ public record PaymentInfoResponse(
         PayType payType,
         BigDecimal amount,
         String orderId,
-        String productName
+        String orderName,
+        String successUrl,
+        String failUrl
 ) {
 
-    public static PaymentInfoResponse of(PayType payType, BigDecimal amount, String orderId, String productName) {
-        return new PaymentInfoResponse(payType, amount, orderId, productName);
+    public static PaymentInfoResponse of(PayType payType, BigDecimal amount, String orderId, String orderName, String successUrl, String failUrl) {
+        return new PaymentInfoResponse(payType, amount, orderId, orderName, successUrl, failUrl);
     }
 
-    public static PaymentInfoResponse from(Payment entity) {
+    public static PaymentInfoResponse from(Payment entity, String successUrl, String failUrl) {
         return PaymentInfoResponse.of(
                 entity.getPayType(),
                 entity.getAmount(),
                 String.format("%019d", entity.getOrder().getId()),
-                entity.getProductName()
+                entity.getProductName(),
+                successUrl,
+                failUrl
         );
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/service/PaymentService.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/service/PaymentService.java
@@ -16,7 +16,7 @@ public interface PaymentService {
     PaymentInfoResponse createPayment(PaymentRequest dto, CustomPrincipal principal);
     Page<PaymentResponseToPage> readPayments(Integer searchMonths, Pageable pageable, CustomPrincipal principal);
     void verifyRequest(String paymentKey, String orderId, BigDecimal amount);
-    PaymentTossDto requestApprovalPayment(String paymentKey, String orderId, BigDecimal amount);
+    void requestApprovalPayment(String paymentKey, String orderId, BigDecimal amount);
     PaymentFailResponse handleRequestFail(String errorCode, String errorMsg, String orderId);
-    PaymentTossDto requestPaymentCancel(RefundRequest request, CustomPrincipal principal);
+    void requestPaymentCancel(RefundRequest request, CustomPrincipal principal);
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
@@ -61,6 +61,12 @@ public class PaymentServiceImpl implements PaymentService {
     @Value("${toss.test.origin-url}")
     private String tossOriginUrl;
 
+    @Value("${toss.test.success-url}")
+    private String tossSuccessUrl;
+
+    @Value("${toss.test.fail-url}")
+    private String tossFailUrl;
+
     @Override
     public PaymentInfoResponse createPayment(PaymentRequest request, CustomPrincipal principal) {
         verifyPrincipal(principal);
@@ -78,13 +84,16 @@ public class PaymentServiceImpl implements PaymentService {
                 .forEach(productId -> {
                     Cart cart = cartRepository.findByProfile_IdAndProduct_Id(profile.getId(), productId)
                             .orElseThrow(() -> new BusinessLogicException(ExceptionCode.CART_NOT_FOUND));
-                    cartRepository.delete(cart);
 
                     OrderDetail orderDetail = orderDetailRepository.save(OrderDetailDto.of(cart.getQuantity()).toEntity(orders, cart.getProduct()));
                     orders.getOrderDetails().add(orderDetail);
                 });
 
-        return PaymentInfoResponse.from(paymentRepository.save(PaymentDto.of(request.payType()).toEntity(orders, profile)));
+        return PaymentInfoResponse.from(
+                paymentRepository.save(PaymentDto.of(request.payType()).toEntity(orders, profile)),
+                tossSuccessUrl,
+                tossFailUrl
+        );
     }
 
     @Override

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
@@ -147,7 +147,7 @@ public class PaymentServiceImpl implements PaymentService {
                         }
                 );
 
-        return response;
+        cartRepository.deleteAllByOrderId(Long.parseLong(orderId));
     }
 
     @Override


### PR DESCRIPTION
## 무슨 이유로 코드를 변경했는지
- FE 팀과 회의하여 API 조정 및 추가
  - 결제 생성 시 클라이언트에게 보내주는 정보 추가 (PaymentInfoResponse) 96a5f468fccb72940394d297dee4d481a7c212f8
  - 결제 Response, Http Status로 성공, 실패만 반환하도록 변경 7fbf19dba4ad7788cb639cb79d576501ca6d555d
  - 결제 실패 시 장바구니 그대로 유지 2dab97e9248b2d2945e0389c47a4be74782841f6
  - 결제 환불 한번에 여러 개 가능하도록 API 변경 737a0a19afca4d6443e2b9575851129c624f27b8
  - 장바구니 추가, 삭제를 한번에 여러 개 가능하도록 API 변경 1956ab186e1bd7fba742ff58788c5edee0fd6133
  - 배송 조회를 위해 주문 상세(OrderDetail) 목록 조회 API 추가 c5ac211e3ac5ce044e3cd7ce22678317b4819ed5

## 관련 이슈
- #138 

## 완료 사항
- This Closes #138 