### PR TITLE
[FE] 결제페이지에서 장바구니 id 데이터 전달

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.9.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3122,6 +3123,29 @@
           "optional": true
         },
         "webpack-plugin-serve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.1.tgz",
+      "integrity": "sha512-HikrdY+IDgRfRYlCTGUQaiCxxDDgM1mQrRbZ6S1HFZX5ZYuJ4o8EstNmhTwHdPl2rTmLxzwSu0b3AyeyTlR+RA==",
+      "dependencies": {
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
           "optional": true
         }
       }
@@ -14643,6 +14667,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -14784,6 +14816,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -19520,6 +19557,17 @@
         "loader-utils": "^2.0.4",
         "schema-utils": "^3.0.0",
         "source-map": "^0.7.3"
+      }
+    },
+    "@reduxjs/toolkit": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.1.tgz",
+      "integrity": "sha512-HikrdY+IDgRfRYlCTGUQaiCxxDDgM1mQrRbZ6S1HFZX5ZYuJ4o8EstNmhTwHdPl2rTmLxzwSu0b3AyeyTlR+RA==",
+      "requires": {
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
       }
     },
     "@remix-run/router": {
@@ -27752,6 +27800,12 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "requires": {}
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -27862,6 +27916,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "reselect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/client/src/app/reducer/productId2Pay.js
+++ b/client/src/app/reducer/productId2Pay.js
@@ -1,0 +1,13 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export const productIdsSlice = createSlice({
+  name: "productIds",
+  initialState: { ids: [] },
+  reducers: {
+    setProductIds: (state, action) => {
+      state.ids = action.payload;
+    },
+  },
+});
+
+export default productIdsSlice.reducer;

--- a/client/src/app/reducer/productId2Pay.js
+++ b/client/src/app/reducer/productId2Pay.js
@@ -10,4 +10,6 @@ export const productIdsSlice = createSlice({
   },
 });
 
+export const { setProductIds } = productIdsSlice.actions;
+
 export default productIdsSlice.reducer;

--- a/client/src/app/store.js
+++ b/client/src/app/store.js
@@ -1,0 +1,5 @@
+import { configureStore } from "@reduxjs/toolkit";
+
+export const store = configureStore({
+  reducer: {},
+});

--- a/client/src/app/store.js
+++ b/client/src/app/store.js
@@ -1,5 +1,8 @@
 import { configureStore } from "@reduxjs/toolkit";
+import productIdsReducer from "./reducer/productId2Pay";
 
 export const store = configureStore({
-  reducer: {},
+  reducer: {
+    productIds: productIdsReducer,
+  },
 });

--- a/client/src/components/cart/CartProductItem.jsx
+++ b/client/src/components/cart/CartProductItem.jsx
@@ -78,7 +78,7 @@ function CartProductItem({ item, data, setData, index, checkedList, setCheckedLi
 
     if (isChecked) {
       checkedList = checkedList.filter((element) => element.id !== item.id);
-      setCheckedList([...checkedList, { id: item.id, quantity, price: item.product.price }]);
+      setCheckedList([...checkedList, { id: item.id, quantity, price: item.product.price, productId: item.product.id }]);
     }
   }, [quantity]);
 

--- a/client/src/components/pay/index.js
+++ b/client/src/components/pay/index.js
@@ -7,6 +7,7 @@ import OrderInfo from "./OrderInfo";
 import ShipInfo from "./ShipInfo";
 import PayInfo from "./PayInfo";
 import InfoCheck from "./InfoCheck";
+import { useSelector } from "react-redux";
 
 const Container = styled.div`
   max-width: 1050px;
@@ -47,6 +48,9 @@ const ButtonWrapper = styled.div`
 `;
 
 function Pay() {
+  const productIds = useSelector((state) => state.productIds.ids);
+
+  console.log(productIds);
   return (
     <Container>
       <TitleContainer>
@@ -58,13 +62,7 @@ function Pay() {
       <InfoCheck />
 
       <ButtonWrapper>
-        <BasicButton
-          children={"결제하기"}
-          font={"20"}
-          radius={"5"}
-          p_height={"14"}
-          p_width={"150"}
-        />
+        <BasicButton children={"결제하기"} font={"20"} radius={"5"} p_height={"14"} p_width={"150"} />
       </ButtonWrapper>
     </Container>
   );

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,13 +1,12 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import { store } from "./app/store";
+import { Provider } from "react-redux";
 
-
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
+  <Provider store={store}>
     <App />
+  </Provider>
 );
-
-
-
-

--- a/client/src/pages/cart/index.js
+++ b/client/src/pages/cart/index.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { useState, useEffect } from "react";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
 
 import { ReactComponent as CartIcon } from "../../assets/cart_icon.svg";
 import CartProductItem from "../../components/cart/CartProductItem";
@@ -11,6 +13,7 @@ import ProductItemSlider from "../../components/ProductItemSlider";
 import { Title, TodayRecommendProducts } from "..";
 
 import BASE_URL from "../../constants/BASE_URL";
+import { setProductIds } from "../../app/reducer/productId2Pay";
 
 const Container = styled.div`
   max-width: 1050px;
@@ -109,6 +112,8 @@ function Cart() {
   const [totalPrice, setTotalPrice] = useState(0);
   const [checkedList, setCheckedList] = useState([]);
   const [selectAllChecked, setSelectAllChecked] = useState(true);
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   useEffect(() => {
     const getCartList = async () => {
@@ -131,7 +136,9 @@ function Cart() {
     (async () => {
       const data = await getCartList();
       setData(data);
-      setCheckedList(data.data.map((element) => ({ id: element.id, quantity: element.quantity, price: element.product.price })));
+      setCheckedList(
+        data.data.map((element) => ({ id: element.id, quantity: element.quantity, price: element.product.price, productId: element.product.id }))
+      );
     })();
   }, []);
 
@@ -152,7 +159,9 @@ function Cart() {
     }
 
     if (selectAllChecked === false) {
-      setCheckedList(data.data.map((element) => ({ id: element.id, quantity: element.quantity, price: element.product.price })));
+      setCheckedList(
+        data.data.map((element) => ({ id: element.id, quantity: element.quantity, price: element.product.price, productId: element.product.id }))
+      );
       setSelectAllChecked(!selectAllChecked);
     }
   };
@@ -182,6 +191,11 @@ function Cart() {
     } catch (error) {
       console.error(error);
     }
+  };
+
+  const handleOrderButtonClick = () => {
+    dispatch(setProductIds(checkedList.map((list) => list.productId)));
+    navigate("/pay");
   };
 
   return (
@@ -235,7 +249,10 @@ function Cart() {
 
         <OrderButtonContainer>
           <BasicButton href={"/collections/best-product"} children={"상품 더 담기"} font={"20"} radius={"5"} p_height={"10"} p_width={"30"} />
-          <ColorButton children={"주문하기"} font={"20"} radius={"5"} p_height={"10"} p_width={"30"} />
+
+          <div onClick={handleOrderButtonClick}>
+            <ColorButton children={"주문하기"} font={"20"} radius={"5"} p_height={"10"} p_width={"30"} />
+          </div>
         </OrderButtonContainer>
       </CartProductListContainer>
 


### PR DESCRIPTION
## 무슨 이유로 코드를 변경했는지
결제페이지에서 필요한 장바구니 id를 리덕스로 상태관리하여 전달

## 새로 사용한 기술 링크
redux toolkit, react-redux

## 관련 이슈
[FE] 결제페이지에서 장바구니 id 데이터 전달 #171 

## 완료 사항
 1. 리덕스 툴킷 설치 및 package.json 커밋
 2. 리덕스 툴킷을 이용하여 결제페이지에서 결제할 상품 아이디 리스트를 받을 수 있도록 코드 작성