### PR TITLE
[FE] 결제페이지 새로고침 시 상태 데이터 초기화되는 현상 수정

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,6 +23,7 @@
         "react-scripts": "5.0.1",
         "react-table": "^7.8.0",
         "redux": "^4.2.0",
+        "redux-persist": "^6.0.0",
         "styled-components": "^5.3.6",
         "styled-reset": "^4.4.4",
         "web-vitals": "^2.1.4"
@@ -14667,6 +14668,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
@@ -27799,6 +27808,12 @@
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "2.4.2",

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "react-scripts": "5.0.1",
     "react-table": "^7.8.0",
     "redux": "^4.2.0",
+    "redux-persist": "^6.0.0",
     "styled-components": "^5.3.6",
     "styled-reset": "^4.4.4",
     "web-vitals": "^2.1.4"

--- a/client/src/app/store.js
+++ b/client/src/app/store.js
@@ -1,8 +1,20 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import productsInfoReducer from "./reducer/productId2Pay";
+import storage from "redux-persist/lib/storage";
+import { persistReducer } from "redux-persist";
+
+const persistConfig = {
+  key: "root",
+  storage,
+};
+
+const persistedReducer = persistReducer(persistConfig, productsInfoReducer);
 
 export const store = configureStore({
   reducer: {
-    productsInfo: productsInfoReducer,
+    productsInfo: persistedReducer,
   },
+  middleware: getDefaultMiddleware({
+    serializableCheck: false,
+  }),
 });

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -3,10 +3,16 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import { store } from "./app/store";
 import { Provider } from "react-redux";
+import { PersistGate } from "redux-persist/integration/react";
+import { persistStore } from "redux-persist";
+
+let persistor = persistStore(store);
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <Provider store={store}>
-    <App />
+    <PersistGate loading={null} persistor={persistor}>
+      <App />
+    </PersistGate>
   </Provider>
 );


### PR DESCRIPTION
## 무슨 이유로 코드를 변경했는지
결제 페이지에서 새로고침시 스토어 상태가 초기화되는 이슈 발생
redux-persist로 이슈 해결

## 새로 사용한 기술 링크
[redux-persist](https://github.com/rt2zz/redux-persist)

## 관련 이슈
[FE] 결제페이지 새로고침 시 상태 데이터 초기화되는 현상 수정 #183 

## 완료 사항
 1. Redux Persist 설치
 2. Redux Persist를 사용하여 초기화되지 않도록 수정