### PR TITLE
[BE] 마이 페이지 카운트 데이터 API 구현 및 잡다한 변경

### DIFF
--- a/server/culinari/src/main/java/com/codestates/culinari/order/entitiy/Orders.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/entitiy/Orders.java
@@ -1,11 +1,14 @@
 package com.codestates.culinari.order.entitiy;
 
 import com.codestates.culinari.audit.AuditingFields;
+import com.codestates.culinari.payment.entity.Payment;
+import com.codestates.culinari.product.entitiy.ProductReviewLike;
 import com.codestates.culinari.user.entitiy.Profile;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +35,10 @@ public class Orders extends AuditingFields {
 
     @OneToMany(mappedBy = "orders")
     private List<OrderDetail> orderDetails = new ArrayList<>();
+
+    @Setter
+    @OneToOne
+    private Payment payment;
 
     private Orders(String id, String address, String receiverName, String receiverPhoneNumber, Profile profile) {
         this.id = id;

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustom.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustom.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface OrderDetailRepositoryCustom {
-    List<OrderDetail> findAllPaidByIdAndPaymentKeyAndProfileId(List<Long> orderDetailIds, String paymentKey, Long profileId);
+    List<OrderDetail> findAllPaidByIdAndProfileId(List<Long> orderDetailIds, Long profileId);
 
     Page<OrderDetail> findAllCreatedAfterAndProfile_Id(LocalDateTime createdAfterDateTime, Long profileId, Pageable pageable);
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustom.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface OrderDetailRepositoryCustom {
     List<OrderDetail> findAllPaidByIdAndProfileId(List<Long> orderDetailIds, Long profileId);
 
     Page<OrderDetail> findAllCreatedAfterAndProfile_Id(LocalDateTime createdAfterDateTime, Long profileId, Pageable pageable);
+
+    Long countOnShippingByProfileId(LocalDateTime createdAfterDateTime, Long profileId);
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustomImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustomImpl.java
@@ -47,16 +47,17 @@ public class OrderDetailRepositoryCustomImpl extends QuerydslRepositorySupport i
     @Override
     public Page<OrderDetail> findAllCreatedAfterAndProfile_Id(LocalDateTime createdAfterDateTime, Long profileId, Pageable pageable) {
         QOrderDetail orderDetail = QOrderDetail.orderDetail;
-        QPayment payment = QPayment.payment;
+        QProduct product = QProduct.product;
+        QProductImage productImage = QProductImage.productImage;
         QRefund refund = QRefund.refund;
-        QProfile profile = QProfile.profile;
 
         JPQLQuery<OrderDetail> query =
                 from(orderDetail)
-                        .innerJoin(orderDetail.orders.profile, profile).fetchJoin()
+                        .innerJoin(orderDetail.product, product).fetchJoin()
+                        .innerJoin(product.productImages, productImage).fetchJoin()
                         .where(orderDetail.createdAt.gt(createdAfterDateTime)
-                                .and(profile.id.eq(profileId))
-                                .and(orderDetail.orders.id.in(JPAExpressions.select(payment.order.id).from(payment).where(payment.paySuccessTf.eq(true))))
+                                .and(orderDetail.orders.profile.id.eq(profileId))
+                                .and(orderDetail.orders.payment.paySuccessTf.eq(true))
                                 .and(orderDetail.id.notIn(JPAExpressions.select(refund.orderDetail.id).from(refund))));
         List<OrderDetail> orderDetails = getQuerydsl().applyPagination(pageable, query).fetch();
 

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustomImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustomImpl.java
@@ -23,20 +23,14 @@ public class OrderDetailRepositoryCustomImpl extends QuerydslRepositorySupport i
     }
 
     @Override
-    public List<OrderDetail> findAllPaidByIdAndPaymentKeyAndProfileId(List<Long> orderDetailIds, String paymentKey, Long profileId) {
+    public List<OrderDetail> findAllPaidByIdAndProfileId(List<Long> orderDetailIds, Long profileId) {
         QOrderDetail orderDetail = QOrderDetail.orderDetail;
-        QPayment payment = QPayment.payment;
         QRefund refund = QRefund.refund;
 
         List<OrderDetail> orderDetails =
                 from(orderDetail)
-                        .where(orderDetail.orders.id.eq(
-                                JPAExpressions.select(payment.order.id).from(payment)
-                                        .where(
-                                                payment.paySuccessTf.eq(true)
-                                                .and(payment.paymentKey.eq(paymentKey))
-                                                .and(payment.profile.id.eq(profileId))
-                                        ))
+                        .where(orderDetail.orders.payment.paySuccessTf.eq(true)
+                                .and(orderDetail.orders.profile.id.eq(profileId))
                                 .and(orderDetail.id.in(orderDetailIds))
                                 .and(orderDetail.id.notIn(JPAExpressions.select(refund.orderDetail.id).from(refund)))
                         )

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrdersRepositoryCustom.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrdersRepositoryCustom.java
@@ -8,4 +8,6 @@ import java.time.LocalDateTime;
 
 public interface OrdersRepositoryCustom {
     Page<Orders> findAllCreatedAfterAndProfile_Id(LocalDateTime createdAfterDateTime, Long profileId, Pageable pageable);
+
+    Long countOrderByProfileId(LocalDateTime createdAfterDateTime, Long profileId);
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrdersRepositoryCustomImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrdersRepositoryCustomImpl.java
@@ -36,4 +36,16 @@ public class OrdersRepositoryCustomImpl extends QuerydslRepositorySupport implem
 
         return new PageImpl<>(orders, pageable, query.fetchCount());
     }
+
+    @Override
+    public Long countOrderByProfileId(LocalDateTime createdAfterDateTime, Long profileId) {
+        QOrders order = QOrders.orders;
+        QProfile profile = QProfile.profile;
+
+        return from(order)
+                .where(order.createdAt.gt(createdAfterDateTime)
+                        .and(profile.id.eq(profileId))
+                        .and(order.payment.paySuccessTf.eq(true)))
+                .fetchCount();
+    }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/CartServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/CartServiceImpl.java
@@ -32,8 +32,6 @@ public class CartServiceImpl implements CartService {
 
     @Override
     public void createCart(CartPost post, CustomPrincipal principal) {
-        verifyPrincipal(principal);
-
         post.cartItems().forEach(cartInfo -> {
                     Product product = productRepository.findById(cartInfo.productId())
                             .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PRODUCT_NOT_FOUND));
@@ -55,15 +53,11 @@ public class CartServiceImpl implements CartService {
     @Transactional(readOnly = true)
     @Override
     public Page<CartResponse> readCarts(Pageable pageable, CustomPrincipal principal) {
-        verifyPrincipal(principal);
-
         return cartRepository.findAllByProfile_Id(pageable, principal.profileId()).map(CartResponse::from);
     }
 
     @Override
     public void updateCart(CartPatch patch, Long cartId, CustomPrincipal principal) {
-        verifyPrincipal(principal);
-
         Cart cart = cartRepository.findByIdAndProfile_Id(cartId, principal.profileId())
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.CART_NOT_FOUND));
 
@@ -73,17 +67,11 @@ public class CartServiceImpl implements CartService {
 
     @Override
     public void deleteCarts(CartDelete delete, CustomPrincipal principal) {
-        verifyPrincipal(principal);
-
         try {
             cartRepository.deleteAllByIdsAndProfile_Id(delete.cartIds(), principal.profileId());
         } catch (Exception e) {
             throw new BusinessLogicException(ExceptionCode.CART_NOT_FOUND);
 
         }
-    }
-
-    public void verifyPrincipal(CustomPrincipal principal) {
-        if (principal == null) throw new BusinessLogicException(ExceptionCode.UNAUTHORIZED);
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/OrdersServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/service/impl/OrdersServiceImpl.java
@@ -36,21 +36,13 @@ public class OrdersServiceImpl implements OrdersService {
 
     @Override
     public Page<OrderResponse> readOrders(Integer searchMonths, Pageable pageable, CustomPrincipal principal) {
-        verifyPrincipal(principal);
-
         return ordersRepository.findAllCreatedAfterAndProfile_Id(LocalDateTime.now().minusMonths(searchMonths), principal.profileId(), pageable)
                 .map(OrderResponse::from);
     }
 
     @Override
     public Page<OrderDetailResponse> readOrderDetails(Integer searchMonths, Pageable pageable, CustomPrincipal principal) {
-        verifyPrincipal(principal);
-
         return orderDetailRepository.findAllCreatedAfterAndProfile_Id(LocalDateTime.now().minusMonths(searchMonths), principal.profileId(), pageable)
                 .map(OrderDetailResponse::from);
-    }
-
-    public void verifyPrincipal(CustomPrincipal principal) {
-        if (principal == null) throw new BusinessLogicException(ExceptionCode.UNAUTHORIZED);
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/dto/RefundDto.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/dto/RefundDto.java
@@ -4,15 +4,14 @@ import com.codestates.culinari.order.entitiy.OrderDetail;
 import com.codestates.culinari.payment.entity.Refund;
 
 public record RefundDto(
-        String paymentKey,
         String cancelReason
 ) {
 
-    public static RefundDto of(String paymentKey, String cancelReason) {
-        return new RefundDto(paymentKey, cancelReason);
+    public static RefundDto of(String cancelReason) {
+        return new RefundDto(cancelReason);
     }
 
-    public Refund toEntity(OrderDetail orderDetail) {
+    public Refund toEntity(OrderDetail orderDetail, String paymentKey) {
         return Refund.of(
                 paymentKey,
                 cancelReason,

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/dto/request/RefundRequest.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/dto/request/RefundRequest.java
@@ -13,18 +13,15 @@ public record RefundRequest (
         @NotNull(message = "해당 값은 필수입니다.")
         @Size(min = 1, message = "최소 1개 이상의 상품을 주문해야합니다.")
         List<@Positive(message = "해당 값은 1이상이어야 합니다.") Long> orderDetailIds,
-        @NotBlank(message = "결제 키는 빈칸일 수 없습니다.")
-        @Length(max = 200, message = "결재 키는 200자 이하입니다.")
-        String paymentKey,
         @NotBlank(message = "환불 사유는 빈칸일 수 없습니다.")
         String cancelReason
 ) {
 
     public static RefundRequest of(List<Long> orderDetailIds, String paymentKey, String cancelReason) {
-        return new RefundRequest(orderDetailIds, paymentKey, cancelReason);
+        return new RefundRequest(orderDetailIds, cancelReason);
     }
 
     public RefundDto toDto() {
-        return RefundDto.of(paymentKey, cancelReason);
+        return RefundDto.of(cancelReason);
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/dto/response/PaymentInfoResponse.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/dto/response/PaymentInfoResponse.java
@@ -9,23 +9,19 @@ public record PaymentInfoResponse(
         PayType payType,
         BigDecimal amount,
         String orderId,
-        String orderName,
-        String successUrl,
-        String failUrl
+        String orderName
 ) {
 
-    public static PaymentInfoResponse of(PayType payType, BigDecimal amount, String orderId, String orderName, String successUrl, String failUrl) {
-        return new PaymentInfoResponse(payType, amount, orderId, orderName, successUrl, failUrl);
+    public static PaymentInfoResponse of(PayType payType, BigDecimal amount, String orderId, String orderName) {
+        return new PaymentInfoResponse(payType, amount, orderId, orderName);
     }
 
-    public static PaymentInfoResponse from(Payment entity, String successUrl, String failUrl) {
+    public static PaymentInfoResponse from(Payment entity) {
         return PaymentInfoResponse.of(
                 entity.getPayType(),
                 entity.getAmount(),
                 entity.getOrder().getId(),
-                entity.getProductName(),
-                successUrl,
-                failUrl
+                entity.getProductName()
         );
     }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
@@ -74,8 +74,6 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     public PaymentInfoResponse createPayment(PaymentRequest request, CustomPrincipal principal) {
-        verifyPrincipal(principal);
-
         Profile profile = profileRepository.getReferenceById(principal.profileId());
         Orders orders = ordersRepository.save(
                 OrderDto.of(
@@ -103,8 +101,6 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     public Page<PaymentResponseToPage> readPayments(Integer searchMonths, Pageable pageable, CustomPrincipal principal) {
-        verifyPrincipal(principal);
-
         return paymentRepository.findAllCreatedAfterAndProfile_Id(LocalDateTime.now().minusMonths(searchMonths), principal.profileId(), pageable)
                 .map(PaymentResponseToPage::from);
     }
@@ -170,7 +166,6 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     public void requestPaymentCancel(RefundRequest request, CustomPrincipal principal) {
-        verifyPrincipal(principal);
         RefundDto dto = request.toDto();
 
         List<OrderDetail> orderDetails =
@@ -198,10 +193,6 @@ public class PaymentServiceImpl implements PaymentService {
 
             refundRepository.save(dto.toEntity(orderDetail, paymentKey));
         });
-    }
-
-    private void verifyPrincipal(CustomPrincipal principal) {
-        if (principal == null) throw new BusinessLogicException(ExceptionCode.UNAUTHORIZED);
     }
 
     private HttpHeaders createAuthHeaders() {

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
@@ -66,12 +66,6 @@ public class PaymentServiceImpl implements PaymentService {
     @Value("${toss.test.origin-url}")
     private String tossOriginUrl;
 
-    @Value("${toss.test.success-url}")
-    private String tossSuccessUrl;
-
-    @Value("${toss.test.fail-url}")
-    private String tossFailUrl;
-
     @Override
     public PaymentInfoResponse createPayment(PaymentRequest request, CustomPrincipal principal) {
         Profile profile = profileRepository.getReferenceById(principal.profileId());

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
@@ -94,11 +94,10 @@ public class PaymentServiceImpl implements PaymentService {
                     orders.getOrderDetails().add(orderDetail);
                 });
 
-        return PaymentInfoResponse.from(
-                paymentRepository.save(PaymentDto.of(request.payType()).toEntity(orders, profile)),
-                tossSuccessUrl,
-                tossFailUrl
-        );
+        Payment payment = paymentRepository.save(PaymentDto.of(request.payType()).toEntity(orders, profile));
+        orders.setPayment(payment);
+
+        return PaymentInfoResponse.from(payment);
     }
 
     @Override

--- a/server/culinari/src/main/java/com/codestates/culinari/product/controller/ProductController.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/product/controller/ProductController.java
@@ -87,7 +87,7 @@ public class ProductController {
     @GetMapping("/{product-id}/review")
     public ResponseEntity getProductReview(
             @PathVariable("product-id") Long productId,
-            @RequestParam(value = "sorted-type",required = false) String sortedType,
+            @RequestParam(value = "sorted_type",required = false) String sortedType,
             @Min (0) @RequestParam(defaultValue = "0",required = false) int page,
             @Positive @RequestParam(defaultValue = "5", required = false) int size
     ){

--- a/server/culinari/src/main/java/com/codestates/culinari/product/repository/ProductLikeRepository.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/product/repository/ProductLikeRepository.java
@@ -11,4 +11,6 @@ public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> 
     ProductLike findByProductIdAndProfileId(Long productId, Long profileId);
 
     void deleteByProductId(Long productId);
+
+    Long countByProfile_Id(Long profileId);
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/product/repository/querydsl/ProductRepositoryCustom.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/product/repository/querydsl/ProductRepositoryCustom.java
@@ -17,4 +17,6 @@ public interface ProductRepositoryCustom{
     Page<Product> findAllFrequentOrderProduct(LocalDateTime createdAfterDateTime, Integer frequency, Long profileId, Pageable pageable);
 
     Page<Product> findBestProducts(List<String> category, List<String> brand, Integer frequency, Pageable pageable);
+
+    Long countFrequentOrderProduct(LocalDateTime createdAfterDateTime, Integer frequency, Long profileId);
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/product/repository/querydsl/ProductRepositoryCustomImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/product/repository/querydsl/ProductRepositoryCustomImpl.java
@@ -137,4 +137,19 @@ public class ProductRepositoryCustomImpl extends QuerydslRepositorySupport imple
 
         return new PageImpl<>(products, pageable, query.fetchCount());
     }
+
+    @Override
+    public Long countFrequentOrderProduct(LocalDateTime createdAfterDateTime, Integer frequency, Long profileId) {
+        QOrderDetail orderDetail = QOrderDetail.orderDetail;
+
+        return from(orderDetail)
+                .select(orderDetail.product.id)
+                .where(orderDetail.createdAt.goe(createdAfterDateTime)
+                        .and(orderDetail.product.id.eq(orderDetail.product.id))
+                        .and(orderDetail.orders.payment.paySuccessTf.eq(true))
+                        .and(orderDetail.orders.profile.id.eq(profileId)))
+                .groupBy(orderDetail.product.id)
+                .having(orderDetail.product.id.count().goe(frequency))
+                .fetchCount();
+    }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/user/controller/MyPageController.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/user/controller/MyPageController.java
@@ -1,0 +1,30 @@
+package com.codestates.culinari.user.controller;
+
+import com.codestates.culinari.config.security.dto.CustomPrincipal;
+import com.codestates.culinari.response.SingleResponseDto;
+import com.codestates.culinari.user.dto.response.MyPageCountResponse;
+import com.codestates.culinari.user.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/mypage")
+public class MyPageController {
+    private final MyPageService myPageService;
+
+    @GetMapping("/count")
+    public ResponseEntity getCount(@AuthenticationPrincipal CustomPrincipal customPrincipal){
+
+        MyPageCountResponse response = myPageService.getMyPageCountData(customPrincipal);
+
+        return new ResponseEntity<>(
+                new SingleResponseDto<>(response),
+                HttpStatus.OK);
+    }
+}

--- a/server/culinari/src/main/java/com/codestates/culinari/user/dto/response/MyPageCountResponse.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/user/dto/response/MyPageCountResponse.java
@@ -1,0 +1,12 @@
+package com.codestates.culinari.user.dto.response;
+
+public record MyPageCountResponse(
+        Long shippingCount,
+        Long orderCount,
+        Long productLikeCount,
+        Long frequentlyOrderedProductCount
+) {
+    public static MyPageCountResponse of(Long shippingCount, Long orderCount, Long productLikeCount, Long frequentlyOrderedProductCount) {
+        return new MyPageCountResponse(shippingCount, orderCount, productLikeCount, frequentlyOrderedProductCount);
+    }
+}

--- a/server/culinari/src/main/java/com/codestates/culinari/user/service/MyPageService.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/user/service/MyPageService.java
@@ -1,0 +1,8 @@
+package com.codestates.culinari.user.service;
+
+import com.codestates.culinari.config.security.dto.CustomPrincipal;
+import com.codestates.culinari.user.dto.response.MyPageCountResponse;
+
+public interface MyPageService {
+    MyPageCountResponse getMyPageCountData(CustomPrincipal principal);
+}

--- a/server/culinari/src/main/java/com/codestates/culinari/user/service/impl/MyPageServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/user/service/impl/MyPageServiceImpl.java
@@ -1,0 +1,35 @@
+package com.codestates.culinari.user.service.impl;
+
+import com.codestates.culinari.config.security.dto.CustomPrincipal;
+import com.codestates.culinari.order.repository.OrderDetailRepository;
+import com.codestates.culinari.order.repository.OrdersRepository;
+import com.codestates.culinari.product.repository.ProductLikeRepository;
+import com.codestates.culinari.product.repository.ProductRepository;
+import com.codestates.culinari.user.dto.response.MyPageCountResponse;
+import com.codestates.culinari.user.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MyPageServiceImpl implements MyPageService {
+    private final OrderDetailRepository orderDetailRepository;
+    private final OrdersRepository ordersRepository;
+    private final ProductLikeRepository productLikeRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    public MyPageCountResponse getMyPageCountData(CustomPrincipal principal) {
+        Long shippingCount = orderDetailRepository.countOnShippingByProfileId(LocalDateTime.now().minusMonths(3), principal.profileId());
+        Long orderCount = ordersRepository.countOrderByProfileId(LocalDateTime.now().minusMonths(3), principal.profileId());
+        Long productLikeCount = productLikeRepository.countByProfile_Id(principal.profileId());
+        Long frequentlyOrderedProductCount = productRepository.countFrequentOrderProduct(LocalDateTime.now().minusMonths(12), 3, principal.profileId());
+
+        return MyPageCountResponse.of(shippingCount, orderCount, productLikeCount,  frequentlyOrderedProductCount);
+    }
+
+}


### PR DESCRIPTION
## 무슨 이유로 코드를 변경했는지
- 마이 페이지에서 요구하는 카운팅 데이터를 읽어올 API 추가
![image](https://user-images.githubusercontent.com/29831584/216312227-1fd8c68e-9255-4428-a85f-a8848b94373e.png)
- 더 간단한 쿼리 작성을 위해 `Payment <-> Orders`를 단방향 매핑에서 양방향로 변경
  - 추가로 DB 수정
- N+1 문제 수정
- 주문 취소 시에 `paymentKey`가 필요하지 않게 변경
- 시큐리티 구현으로 인해 필요없어진 `verifyPrincipal` 함수 삭제

## 관련 이슈
- #84 
- #138  
- #240 
- #241
- #247 

## 완료 사항
- This closes #240 
