### PR TITLE
[BE] 환불한 주문, 주문 상세 조회하지 않기

### DIFF
--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustom.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface OrderDetailRepositoryCustom {
     Page<OrderDetail> findAllCreatedAfterAndProfile_Id(LocalDateTime createdAfterDateTime, Long profileId, Pageable pageable);
 
     Long countOnShippingByProfileId(LocalDateTime createdAfterDateTime, Long profileId);
+
+    String findPaymentKey(Long orderId);
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustomImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrderDetailRepositoryCustomImpl.java
@@ -77,4 +77,14 @@ public class OrderDetailRepositoryCustomImpl extends QuerydslRepositorySupport i
                         .and(orderDetail.statusType.eq(StatusType.ON_SHIPPING)))
                 .fetchCount();
     }
+
+    @Override
+    public String findPaymentKey(Long orderId) {
+        QOrderDetail orderDetail = QOrderDetail.orderDetail;
+
+        return from(orderDetail)
+                .select(orderDetail.orders.payment.paymentKey)
+                .where(orderDetail.id.eq(orderId))
+                .fetchOne();
+    }
 }

--- a/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrdersRepositoryCustomImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/order/repository/querydsl/OrdersRepositoryCustomImpl.java
@@ -1,8 +1,10 @@
 package com.codestates.culinari.order.repository.querydsl;
 
 import com.codestates.culinari.order.entitiy.Orders;
+import com.codestates.culinari.order.entitiy.QOrderDetail;
 import com.codestates.culinari.order.entitiy.QOrders;
 import com.codestates.culinari.payment.entity.QPayment;
+import com.codestates.culinari.payment.entity.QRefund;
 import com.codestates.culinari.user.entitiy.QProfile;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
@@ -23,15 +25,21 @@ public class OrdersRepositoryCustomImpl extends QuerydslRepositorySupport implem
     @Override
     public Page<Orders> findAllCreatedAfterAndProfile_Id(LocalDateTime createdAfterDateTime, Long profileId, Pageable pageable) {
         QOrders order = QOrders.orders;
+        QOrderDetail orderDetail = QOrderDetail.orderDetail;
         QPayment payment = QPayment.payment;
         QProfile profile = QProfile.profile;
+        QRefund refund = QRefund.refund;
 
         JPQLQuery<Orders> query =
                 from(order)
                         .innerJoin(order.profile, profile).fetchJoin()
                         .where(order.createdAt.gt(createdAfterDateTime)
                                 .and(profile.id.eq(profileId))
-                                .and(order.id.in(JPAExpressions.select(payment.order.id).from(payment).where(payment.paySuccessTf.eq(true)))));
+                                .and(order.id.in(JPAExpressions.select(payment.order.id).from(payment).where(payment.paySuccessTf.eq(true)))))
+                        .innerJoin(order.orderDetails, orderDetail).fetchJoin()
+                        .where(orderDetail.id.notIn(JPAExpressions.select(refund.orderDetail.id).from(refund)))
+                        .where(order.orderDetails.isNotEmpty());
+
         List<Orders> orders = getQuerydsl().applyPagination(pageable, query).fetch();
 
         return new PageImpl<>(orders, pageable, query.fetchCount());

--- a/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
+++ b/server/culinari/src/main/java/com/codestates/culinari/payment/service/impl/PaymentServiceImpl.java
@@ -167,7 +167,7 @@ public class PaymentServiceImpl implements PaymentService {
 
         // 들어온 모든 OrderDetailIds 가 같은 결제 키를 가진다는 전제로 흘러감
         // N+1 문제 개선 에서 수정할 예정
-        String paymentKey = orderDetails.get(0).getOrders().getPayment().getPaymentKey();
+        String paymentKey = orderDetailRepository.findPaymentKey(orderDetails.get(0).getId());
 
         orderDetails.forEach(orderDetail -> {
             JSONObject params = new JSONObject();


### PR DESCRIPTION
## 무슨 이유로 코드를 변경했는지
- 환불한 주문, 주문상세의 경우 배송 조회와 주문 목록 조회 시 보이지 않게 함

## 관련 이슈
- #138 

## 완료 사항
- #138 